### PR TITLE
Add shared queue binding, for multiple *redundant* consumers

### DIFF
--- a/HOLMS.Messaging/IMessageChannel.cs
+++ b/HOLMS.Messaging/IMessageChannel.cs
@@ -3,7 +3,9 @@
 namespace HOLMS.Messaging {
     public interface IMessageChannel {
         void Publish(string topic, IMessage msg);
-        IMessageListener CreateListenerForTopics(MessageListener.MessageReceivedHandler h,
+        IMessageListener BindSharedQueue(MessageListener.MessageReceivedHandler h,
+            string[] topics, string queueName);
+        IMessageListener BindPrivateQueue(MessageListener.MessageReceivedHandler h,
             string[] topics);
         void Close();
     }

--- a/HOLMS.Messaging/MessageChannel.cs
+++ b/HOLMS.Messaging/MessageChannel.cs
@@ -17,7 +17,15 @@ namespace HOLMS.Messaging {
                 topic, null, msg.ToByteArray());
         }
 
-        public IMessageListener CreateListenerForTopics(MessageListener.MessageReceivedHandler h,
+        public IMessageListener BindSharedQueue(MessageListener.MessageReceivedHandler h, string[] topics,
+                string queueName) {
+            var ml = new MessageListener(_l, _m, topics, queueName);
+            ml.MessageReceived += h;
+
+            return ml;
+        }
+
+        public IMessageListener BindPrivateQueue(MessageListener.MessageReceivedHandler h,
                 string[] topics) {
             var ml = new MessageListener(_l, _m, topics);
             ml.MessageReceived += h;

--- a/HOLMS.Messaging/MessageConnectionFactory.cs
+++ b/HOLMS.Messaging/MessageConnectionFactory.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net.Security;
-using System.Runtime.Remoting.Channels;
 using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 

--- a/HOLMS.Messaging/Tests/FakeRabbitChannel.cs
+++ b/HOLMS.Messaging/Tests/FakeRabbitChannel.cs
@@ -18,7 +18,11 @@ namespace HOLMS.Messaging.Tests {
             Publication?.Invoke(topic, msg);
         }
 
-        public IMessageListener CreateListenerForTopics(MessageListener.MessageReceivedHandler h, string[] topics) {
+        public IMessageListener BindSharedQueue(MessageListener.MessageReceivedHandler h, string[] topics, string queueName) {
+            return new FakeMessageListener();
+        }
+
+        public IMessageListener BindPrivateQueue(MessageListener.MessageReceivedHandler h, string[] topics) {
             return new FakeMessageListener();
         }
 


### PR DESCRIPTION
Currently, we create a randomly-named queue every time we connect to a Rabbit exchange.

As a consequence, two copies of the application server connected to the same broker will each get their own private copy of the messages their listeners subscribe to, meaning the handlers will get run once by each server instance, which is wrong.

This change allows binding to a named, durable queue, e.g. "operations_message_router", which allows multiple copies of the application server to run side-by-side, with at-most-once message delivery to the group at large. 